### PR TITLE
feat: add only_cwd option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ The extension provides the following options:
   If you're opening some logs or other temporary files, you can configure the ignore
   patters in order not to clutter the pickers.
 
+- `only_cwd` (default `false`).
+
+  Show only files in the cwd.
+
 - `transform_file_path` (default `function(file_path) return file_path end`).
 
   This is a Lua function to modify the file path for each entry in the pickers,

--- a/lua/telescope/_extensions/recent_files/recent_files_picker.lua
+++ b/lua/telescope/_extensions/recent_files/recent_files_picker.lua
@@ -12,6 +12,7 @@ local options
 local defaults = {
   stat_files = true,
   ignore_patterns = {"/tmp/"},
+  only_cwd = false,
   transform_file_path = function (path)
     return path
   end,
@@ -66,6 +67,12 @@ local function is_ignored(file_path)
   return false
 end
 
+local function is_in_cwd(file_path)
+  local cwd = vim.loop.cwd()
+  cwd = cwd:gsub([[\]], [[\\]])
+  return vim.fn.matchstrpos(file_path, cwd)[2] ~= -1
+end
+
 local function add_recent_file(result_list, result_map, file_path)
   if options.transform_file_path then
     file_path = options.transform_file_path(file_path)
@@ -79,6 +86,10 @@ local function add_recent_file(result_list, result_map, file_path)
   if should_add and options.stat_files and not stat(file_path) then
     should_add = false
   end
+  if should_add and options.only_cwd and not is_in_cwd(file_path) then
+    should_add = false
+  end
+
   if should_add then
     table.insert(result_list, file_path)
     result_map[file_path] = true


### PR DESCRIPTION
Add an option to only show recent files only for current working directory, similar to
https://github.com/nvim-telescope/telescope.nvim/blob/b923665e64380e97294af09117e50266c20c71c7/doc/telescope.txt#L1202